### PR TITLE
MSONZE-87 Error al passar de mes pel datepicker del calendari

### DIFF
--- a/src/sakai/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_new.vm
+++ b/src/sakai/calendar/calendar-tool/tool/src/webapp/vm/calendar/chef_calendar_new.vm
@@ -382,7 +382,8 @@ $(function() {
 					ashidden:{
 						month:"month",
 						day:"day",
-						year:"yearSelect"
+						year:"yearSelect",
+						iso8601: 'newCalendarDateISO8601'
 					}
 				});
 			</script>


### PR DESCRIPTION
Hay algún tipo de conflicto con el editor del mensaje del evento (si borramos el editor el problema desaparece) y el datepicker sin indicar hh:mm:ss.
Al indicar hh:mm:ss gracias al input hidden ISO8601, el problema también desaparece.